### PR TITLE
Added quick and dirty Linux linking, might or might not merge this

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,14 @@
 cmake_minimum_required (VERSION 2.8)
 project (GameFromScratch)
 
-# Link against Allegro libraries
+IF(WIN32)
+# Link against Allegro libraries if on windows
 set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -lallegro")
-
+ENDIF(WIN32)
 # Put the binary file in /bin
 set (EXECUTABLE_OUTPUT_PATH ${CMAKE_CURRENT_BINARY_DIR}/bin)
 
 add_subdirectory (src)
+
+
+    

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,8 @@
 cmake_minimum_required (VERSION 2.8)
 project (GameFromScratch)
 
-IF(WIN32)
-# Link against Allegro libraries if on windows
-set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -lallegro")
-ENDIF(WIN32)
+#this seems to be for allegro 4
+#set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -lallegro")
 # Put the binary file in /bin
 set (EXECUTABLE_OUTPUT_PATH ${CMAKE_CURRENT_BINARY_DIR}/bin)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,3 +4,7 @@ file(GLOB GameFromScratch_src
 )
 
 add_executable (GameFromScratch ${GameFromScratch_src})
+#this checks if the filesystem is linux and links allegro and Opengl
+IF(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+target_link_libraries(GameFromScratch "-L/usr/local/lib -lallegro"  )
+ENDIF(${CMAKE_SYSTEM_NAME} MATCHES "Linux")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,5 +6,7 @@ file(GLOB GameFromScratch_src
 add_executable (GameFromScratch ${GameFromScratch_src})
 #this checks if the filesystem is linux and links allegro and Opengl
 IF(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
-target_link_libraries(GameFromScratch "-L/usr/local/lib -lallegro"  )
+find_package(PkgConfig)
+pkg_check_modules (ALLEGRO REQUIRED allegro-5.0) 
+target_link_libraries(GameFromScratch ${ALLEGRO_LDFLAGS}  )
 ENDIF(${CMAKE_SYSTEM_NAME} MATCHES "Linux")


### PR DESCRIPTION
 added a check in the cmakelists.txt files which detects windows and inux and links apropriately. Linux linking is currently hardcoded as a string and has to be updated manually. We might want to make this detect automatically. 

Also the detection is currently split on top level ( detects windows ) and src level (detects linux). Might want to change this.
